### PR TITLE
Fixed getting GoLang environment values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@ BUILD_RAND_NAME ?= $(shell tr -dc a-z0-9 </dev/urandom | head -c 13)
 
 IMAGE_DEBIAN11 := geerlingguy/docker-debian11-ansible:latest
 IMAGE_DEBIAN11_PYTHON := '3.9'
-IMAGE_UBUNTU2004 := geerlingguy/docker-ubuntu2004-ansible:latest
+IMAGE_DEBIAN12 := geerlingguy/docker-debian12-ansible:latest
+IMAGE_DEBIAN12_PYTHON := '3.11'
+
+# The following Ubuntu images are from:
+# 	- https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt
+IMAGE_UBUNTU2004 := ubuntu2004
 IMAGE_UBUNTU2004_PYTHON := '3.8'
-IMAGE_UBUNTU2204 := geerlingguy/docker-ubuntu2204-ansible:latest
+IMAGE_UBUNTU2204 := ubuntu2204
 IMAGE_UBUNTU2204_PYTHON := 3.10
 
 DEFAULT_IMAGE_NAME := DEBIAN11
@@ -16,7 +21,7 @@ ANSIBLE_TEST_SANITY_EXCLUDES := \
 		scripts/setup-macports.sh \
 		.gitignore
 
-integration_phony_targets := $(addprefix integration-, debian11 ubuntu2004 ubuntu2204)
+integration_phony_targets := $(addprefix integration-, debian11 debian12 ubuntu2004 ubuntu2204)
 
 .PHONY: \
 		$(integration_phony_targets) \
@@ -33,16 +38,7 @@ all: pre-commit
 
 pre-commit: super-linter sanity units integration
 
-# TODO - Add back once Ansible-core 2.15 is released:
-#   - integration-ubuntu2004
-#   - integration-ubuntu2204
-# There have been cgroup changes in Ubuntu and others in Docker that are
-# causing issues.  These should be resolved in Ansible-core 2.15.  Release
-# schedule is in:
-#   - https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-release-cycle
-# Changes seem to be in:
-#   - https://github.com/ansible/ansible/commit/04fc98c794d425a42f83a062c163c981d8751512
-integration: integration-debian11 # TODO - integration-ubuntu2004 integration-ubuntu2204
+integration: integration-debian11 integration-ubuntu2004 integration-ubuntu2204  # TODO - integration-debian12
 
 sanity:
 	$(info $(SECTION))

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -42,6 +42,7 @@ tags: []
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
+  'ansible.utils': '*'
   'community.general': '*'
 
 # The URL of the originating SCM repository

--- a/roles/global_defaults/defaults/main.yml
+++ b/roles/global_defaults/defaults/main.yml
@@ -4,4 +4,7 @@ avinode_devenv_force_upgrade_all: false
 avinode_devenv_prefix: /opt/devenv
 
 avinode_devenv_packages_update_cache: false
+
+_avinode_devenv_go_arch_command: eval "$(go env)"; echo $GOHOSTARCH
+_avinode_devenv_go_platform_command: eval "$(go env)"; echo $GOOS
 ...

--- a/roles/global_defaults/tasks/main.yaml
+++ b/roles/global_defaults/tasks/main.yaml
@@ -49,9 +49,9 @@
     - avinode_devenv_global_defaults
 
 
-# -----------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Get GoLang settings
-# -----------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 - name: Ensure golang is installed on Debian OS family.
   ansible.builtin.apt:
     name: golang
@@ -73,11 +73,14 @@
   when: ansible_os_family == 'Darwin'
   tags:
     - avinode_devenv_global_defaults
-# TODO - Add a HomeBrew option in a future release.
 
+#----
+# avinode_devenv_go_arch
+#----
 - name: Fecth GOHOSTARCH.
+    # eval "$( {{ _avinode_devenv_go_env_command }} )"; echo $GOHOSTARCH
   ansible.builtin.shell: |
-    eval "$(go tool dist env)"; echo $GOHOSTARCH
+    {{ _avinode_devenv_go_arch_command }}
   register: __avinode_devenv_go_arch
   tags:
     - avinode_devenv_global_defaults
@@ -91,24 +94,35 @@
   tags:
     - avinode_devenv_global_defaults
 
+- name: Assert that avinode_devenv_go_arch is set.
+  ansible.builtin.assert:
+    fail_msg: avinode_devenv_go_arch must have a value
+    that:
+      - avinode_devenv_go_arch | length > 0
+  tags:
+    - avinode_devenv_global_defaults
+
 # On Mac with M1 processor we can fall back to amd64 using rosetta
 - name: Has fallback arch Apple M1
   ansible.builtin.set_fact:
-    avinode_devenv_go_arch: "{{ avinode_devenv_go_arch + [ 'amd64' ] }}"
+    avinode_devenv_go_arch: "{{ avinode_devenv_go_arch + ['amd64'] }}"
   when: ansible_os_family == 'Darwin' and 'arm64' in avinode_devenv_go_arch
   tags:
     - avinode_devenv_global_defaults
 
 - name: Has fallback arch on ARM64 based Linux
   ansible.builtin.set_fact:
-    avinode_devenv_go_arch: "{{ avinode_devenv_go_arch + [ 'arm' ] }}"
+    avinode_devenv_go_arch: "{{ avinode_devenv_go_arch + ['arm'] }}"
   when: ansible_system == 'Linux' and 'arm64' in avinode_devenv_go_arch
   tags:
     - avinode_devenv_global_defaults
 
+#----
+# avinode_devenv_go_platform
+#----
 - name: Fecth GOOS.
   ansible.builtin.shell: |
-    eval "$(go tool dist env)"; echo $GOOS
+    {{ _avinode_devenv_go_platform_command }}
   register: __avinode_devenv_go_platform
   tags:
     - avinode_devenv_global_defaults
@@ -119,4 +133,13 @@
   when: avinode_devenv_go_platform is not defined
   tags:
     - avinode_devenv_global_defaults
+
+- name: Assert that avinode_devenv_go_platform is set.
+  ansible.builtin.assert:
+    fail_msg: avinode_devenv_go_platform must have a value
+    that:
+      - avinode_devenv_go_platform | length > 0
+  tags:
+    - avinode_devenv_global_defaults
+
 ...

--- a/tests/integration/targets/role_global_defaults/tasks/main.yaml
+++ b/tests/integration/targets/role_global_defaults/tasks/main.yaml
@@ -1,0 +1,37 @@
+---
+- name: Reset avinode_devenv_go_* facts at start of test.
+  ansible.utils.update_fact:
+    updates:
+      - path: avinode_devenv_go_arch
+        value: ''
+      - path: avinode_devenv_go_platform
+        value: ''
+  ignore_errors: true
+
+- name: Happy test for avinode.devenv.global_defaults
+  block:
+    - name: Baseline test of avinode.devenv.global_defaults
+      ansible.builtin.import_role:
+        name: avinode.devenv.global_defaults
+    - name: Assert that avinode_devenv_go_platform is set.
+      ansible.builtin.assert:
+        fail_msg: avinode_devenv_go_platform must have been set.
+        that:
+          - avinode_devenv_go_platform | length > 0
+    - name: Assert that avinode_devenv_go_arch is set.
+      ansible.builtin.assert:
+        fail_msg: avinode_devenv_go_arch must have been set.
+        that:
+          - avinode_devenv_go_arch | length > 0
+  always:
+    - name: Reset avinode_devenv_go_* facts at end of test.
+      ansible.utils.update_fact:
+        updates:
+          - path: avinode_devenv_go_arch
+            value: ''
+          - path: avinode_devenv_go_platform
+            value: ''
+
+# TODO - Figure out how to add unhappy tests.
+
+...


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### Checklist

Please Confirm that you have completed the following:

- [X] Executed and successfully completed `make pre-commit`.

### Description

Fixed getting GoLang environment values.  This helps fix issues with pulling Helm, Kubectl, and other command line tools, where the URL is built using the Go platform and OS information.